### PR TITLE
task/56239957: Mutation observer (poc) file setup.

### DIFF
--- a/bindit/src/.internal/mutation-observer.ts
+++ b/bindit/src/.internal/mutation-observer.ts
@@ -1,0 +1,25 @@
+export type MutationType = 'childList' | 'attributes' | 'subtree';
+
+export function bindItViaMutationObserver(
+    targetElement: Element,
+    config: { attributes?: true, childList?: true, subtree?: true }
+): void {
+
+    const onMutation = (mutation: MutationRecord): void => {
+        if (mutation.type === 'childList') {
+            console.log("Child nodes updated");
+        } else if (mutation.type === "attributes") {
+            console.log(`The ${mutation.attributeName} attribute was modified.`);
+        }
+    };
+    const callback = (mutationList: MutationRecord[]) => mutationList.forEach(onMutation);
+
+    const observer = new MutationObserver(callback);
+
+    observer.observe(targetElement, config);
+
+    //TODO: Clean up subscription - observer.disconnect();
+};
+
+
+export default bindItViaMutationObserver;

--- a/bindit/src/main.ts
+++ b/bindit/src/main.ts
@@ -2,6 +2,7 @@ import './style.css'
 import typescriptLogo from './typescript.svg'
 import viteLogo from '/vite.svg'
 import { setupCounter } from './counter.ts'
+import bindItViaMutationObserver from './.internal/mutation-observer.ts'
 
 document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   <div>
@@ -21,4 +22,11 @@ document.querySelector<HTMLDivElement>('#app')!.innerHTML = `
   </div>
 `
 
-setupCounter(document.querySelector<HTMLButtonElement>('#counter')!)
+setupCounter(document.querySelector<HTMLButtonElement>('#counter')!);
+
+export const BindIt = {
+  bindItViaMutationObserver: bindItViaMutationObserver
+}
+
+const targetNode= document.querySelector('#app')!;
+BindIt.bindItViaMutationObserver(targetNode, { attributes: true, childList: true, subtree: true })

--- a/bindit/tsconfig.json
+++ b/bindit/tsconfig.json
@@ -19,5 +19,5 @@
     "noUnusedParameters": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src"]
+  "include": ["src", "src/.internal/mutation-observer-binding.ts"]
 }


### PR DESCRIPTION
### Add mutation observer

Base setup to observe app's mutations - obviously very inefficient at the moment as it observes all changes, but this will further be made more efficient via configuration to drill specifically into the properties desired to be observed.

Once this is done, I need to experiment with callbacks on mutations to see if two-way data binding can be done efficiently like this. 

<img width="518" alt="image" src="https://github.com/geekburton/bindit/assets/104988980/48edfbce-620c-41f0-a863-06035448c9e3">
